### PR TITLE
os.path.join para que funcione en cualquier sistema operativo

### DIFF
--- a/App/config.py
+++ b/App/config.py
@@ -3,4 +3,4 @@ import sys
 file_path = os.path.join(os.path.dirname(__file__), '..')
 file_dir = os.path.dirname(os.path.realpath('__file__'))
 sys.path.insert(0, os.path.abspath(file_path))
-data_dir = file_dir + '/Data/'
+data_dir = os.path.join(file_dir, 'Data')

--- a/App/controller.py
+++ b/App/controller.py
@@ -27,6 +27,7 @@
 import config as cf
 import model
 import csv
+import os
 
 """
 El controlador se encarga de mediar entre la vista y el modelo.
@@ -66,7 +67,7 @@ def loadBooks(catalog):
     cada uno de ellos, se crea en la lista de autores, a dicho autor y una
     referencia al libro que se esta procesando.
     """
-    booksfile = cf.data_dir + 'GoodReads/books-small.csv'
+    booksfile = os.path.join(cf.data_dir, 'GoodReads', 'books-small.csv')
     input_file = csv.DictReader(open(booksfile, encoding='utf-8'))
     for book in input_file:
         model.addBook(catalog, book)
@@ -77,7 +78,8 @@ def loadTags(catalog):
     """
     Carga todos los tags del archivo y los agrega a la lista de tags
     """
-    tagsfile = cf.data_dir + 'GoodReads/tags.csv'
+    tagsfile = os.path.join(cf.data_dir, 'GoodReads', 'tags.csv')
+
     input_file = csv.DictReader(open(tagsfile, encoding='utf-8'))
     for tag in input_file:
         model.addTag(catalog, tag)
@@ -88,7 +90,7 @@ def loadBooksTags(catalog):
     """
     Carga la información que asocia tags con libros.
     """
-    booktagsfile = cf.data_dir + 'GoodReads/book_tags-small.csv'
+    booktagsfile = os.path.join(cf.data_dir, 'GoodReads', 'book_tags-small.csv')
     input_file = csv.DictReader(open(booktagsfile, encoding='utf-8'))
     for booktag in input_file:
         model.addBookTag(catalog, booktag)


### PR DESCRIPTION
Hacer + '/' + para unir carpetas causa problemas cuando el separador del sistema operativo no es '/'.
En este pull request se remplaza por os.path.join que funciona en cualquier sistema operativo.